### PR TITLE
add caveat with init command instructions

### DIFF
--- a/Formula/nitro.rb
+++ b/Formula/nitro.rb
@@ -30,6 +30,16 @@ class Nitro < Formula
     bin.install "nitro"
   end
 
+  def caveats
+    <<~EOS
+
+      Next, initialize Nitro by running
+
+        nitro init
+
+    EOS
+  end
+
   test do
     system "#{bin}/nitro --version"
   end


### PR DESCRIPTION
### Description

[Edit: moved the motivation to the new issue]

Homebrew supports [caveats](https://github.com/Homebrew/brew/blob/master/docs/Formula-Cookbook.md#caveats), which are printed in the terminal after successful installation.

This PR adds a simple caveat instructing users to run the init command.


### Related issues

~Issues aren't supported in this repo.~ Resolves #1